### PR TITLE
git2: disable default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ license = "MIT AND Apache-2.0"
 
 [dependencies]
 chrono = "0.4.13"
-git2 = "0.13.8"
+git2 = { version = "0.13.8", default-features = false }


### PR DESCRIPTION
By default git2 depends on openssl for https transport support, which can be hard to build.

It looks like shadow-rs is read-only so it doesn't really need any of the default features.