### PR TITLE
Make embedded timestamps timezone independent

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,7 @@
 use crate::build::{ConstType, ConstVal, ShadowConst};
 use crate::ci::CiType;
 use crate::err::*;
+use crate::time::BuildTime;
 use crate::Format;
 use chrono::SecondsFormat;
 use std::collections::HashMap;
@@ -76,7 +77,7 @@ impl Git {
         #[cfg(feature = "git2")]
         {
             use crate::git::git2_mod::git_repo;
-            use chrono::{DateTime, Local, NaiveDateTime, Utc};
+            use chrono::{DateTime, NaiveDateTime, Utc};
 
             let repo = git_repo(path).map_err(ShadowError::new)?;
             let reference = repo.head().map_err(ShadowError::new)?;
@@ -108,8 +109,7 @@ impl Git {
 
             let time_stamp = commit.time().seconds().to_string().parse::<i64>()?;
             let dt = NaiveDateTime::from_timestamp(time_stamp, 0);
-            let date_time = DateTime::<Utc>::from_utc(dt, Utc);
-            let date_time: DateTime<Local> = DateTime::from(date_time);
+            let date_time = BuildTime::Utc(DateTime::<Utc>::from_utc(dt, Utc));
             self.update_str(COMMIT_DATE, date_time.human_format());
 
             self.update_str(COMMIT_DATE_2822, date_time.to_rfc2822());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ use env::*;
 use git::*;
 
 use crate::ci::CiType;
+use crate::time::BuildTime;
 use std::collections::HashMap;
 use std::env as std_env;
 use std::fs::File;
@@ -354,7 +355,7 @@ impl Shadow {
 /// Author by:https://www.github.com/baoyachi
 /// The build script repository:https://github.com/baoyachi/shadow-rs
 /// Create time by:{}"#,
-            Local::now().human_format()
+            BuildTime::Local(Local::now()).human_format()
         );
         writeln!(&self.f, "{}\n\n", desc)?;
         Ok(())

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,48 +1,59 @@
 use crate::Format;
-use chrono::{DateTime, Local, TimeZone};
+use chrono::{DateTime, SecondsFormat, Local, TimeZone, Utc};
 
-pub fn now_data_time() -> DateTime<Local> {
+pub enum BuildTime {
+    Local(DateTime<Local>),
+    Utc(DateTime<Utc>),
+}
+
+pub fn now_data_time() -> BuildTime {
     match std::env::var_os("SOURCE_DATE_EPOCH") {
-        None => Local::now(),
+        None => BuildTime::Local(Local::now()),
         Some(timestamp) => {
             let epoch = timestamp
                 .into_string()
                 .expect("Input SOURCE_DATE_EPOCH could not be parsed")
                 .parse::<i64>()
                 .expect("Input SOURCE_DATE_EPOCH could not be cast to a number");
-            Local.timestamp(epoch, 0)
+            BuildTime::Utc(Utc.timestamp(epoch, 0))
         }
     }
 }
 
-impl<Tz: TimeZone> Format for DateTime<Tz>
-where
-    Tz::Offset: std::fmt::Display,
-{
+impl BuildTime {
+    pub fn to_rfc2822(&self) -> String {
+        match self {
+            BuildTime::Local(dt) => dt.to_rfc2822(),
+            BuildTime::Utc(dt) => dt.to_rfc2822(),
+        }
+    }
+
+    pub fn to_rfc3339_opts(&self, secform: SecondsFormat, use_z: bool) -> String {
+        match self {
+            BuildTime::Local(dt) => dt.to_rfc3339_opts(secform, use_z),
+            BuildTime::Utc(dt) => dt.to_rfc3339_opts(secform, use_z),
+        }
+    }
+}
+
+impl Format for BuildTime {
     fn human_format(&self) -> String {
-        self.format("%Y-%m-%d %H:%M:%S %:z").to_string()
+        let fmt = "%Y-%m-%d %H:%M:%S %:z";
+        match self {
+            BuildTime::Local(dt) => dt.format(fmt).to_string(),
+            BuildTime::Utc(dt) => dt.format(fmt).to_string(),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
 
     #[test]
-    fn test_now_data_time() {
+    fn test_source_date_epoch() {
         std::env::set_var("SOURCE_DATE_EPOCH", "1628080443");
         let time = now_data_time();
-        let now = Local::now();
-        assert!(time < now);
-    }
-
-    #[test]
-    fn test_timezone_utc() {
-        std::env::set_var("SOURCE_DATE_EPOCH", "1628080443");
-        std::env::set_var("TZ", "UTC");
-        let time = now_data_time();
-        let utc = Utc.timestamp(1628080443, 0);
-        assert_eq!(time.human_format(), utc.human_format())
+        assert_eq!(time.human_format(), "2021-08-04 12:34:03 +00:00");
     }
 }


### PR DESCRIPTION
This is a follow-up for #61, the value of `TZ` still has an impact on the binary (removing the `env::set_var` call in one of the tests makes the test fail as well):
```
---- time::tests::test_timezone_utc stdout ----
thread 'time::tests::test_timezone_utc' panicked at 'assertion failed: `(left == right)`
  left: `"2021-08-04 14:34:03 +02:00"`,
 right: `"2021-08-04 12:34:03 +00:00"`', src/time.rs:46:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With this patch `SOURCE_DATE_EPOCH` makes the embedded timestamp use UTC without build-time localization of the timezone. It also removes build-time localization when embedding the most-recent-git-commit timestamp (this didn't show up in our tests because we've tested with a sourcecode from a tarball).

The code could be simplified by always using UTC, then localize the timezone at runtime if needed.

I've dropped one of the tests because calling `Local::now();` after `now_data_time();` is always going to give you a greater value, unless SOURCE_DATE_EPOCH is explicitly set to a value in the future.

Thanks!