### PR TITLE
Rebuild on changes to `SOURCE_DATE_EPOCH`

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -7,6 +7,11 @@ pub enum BuildTime {
 }
 
 pub fn now_data_time() -> BuildTime {
+    // Enable reproducibility for uses of `now_data_time` by respecting the
+    // `SOURCE_DATE_EPOCH` env variable.
+    //
+    // https://reproducible-builds.org/docs/source-date-epoch/
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
     match std::env::var_os("SOURCE_DATE_EPOCH") {
         None => BuildTime::Local(Local::now()),
         Some(timestamp) => {


### PR DESCRIPTION
Cargo supports some pragmas to force rebuilds if non-Rust sources become "dirtied".

This PR forces cargo to rebuild if the `SOURCE_DATE_EPOCH` env variable changes
since it will change how `now_data_time` and things derived from it are computed.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-env-changedname