### PR TITLE
fix: Replace clap_version with clap_long_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ fn main() {
 
     //shadow-rs built in const   
     println!("{}", build::version());           // the version (description binary detail information)
-    println!("{}", build::clap_version());      // usually used by clap crates version() (description binary detail information)
+    println!("{}", build::clap_long_version()); // usually used by clap crates version() (description binary detail information)
     println!("{}", build::PKG_VERSION);         // current package version. e.g. '1.3.15-beta2'  
     println!("{}", build::PKG_VERSION_MAJOR);   //current package major version. e.g. '1'  
     println!("{}", build::PKG_VERSION_MINOR);   //current package minor version. e.g. '3'  
@@ -152,7 +152,7 @@ with [`clap`](https://github.com/baoyachi/shadow-rs/blob/master/example_shadow/s
 | const/fn | example |
 | ------ | ------ |
 | version() | support mini version information.It's use easy. |
-| clap_version() | support mini version information for clap.It's use easy. |
+| clap_long_version() | support mini version information for clap.It's use easy. |
 | BRANCH | master/develop |
 | TAG | v1.0.0 |
 | SHORT_COMMIT | 8405e28e |  

--- a/example_shadow/src/main.rs
+++ b/example_shadow/src/main.rs
@@ -6,7 +6,7 @@ shadow!(build);
 
 fn main() {
     App::new("example_shadow")
-        .version(build::clap_version().as_str())
+        .long_version(build::clap_long_version().as_str())
         .get_matches(); //USAGE: ./example_shadow -V
 
     // shadow-rs built in function
@@ -23,7 +23,7 @@ fn main() {
 
 #[allow(dead_code)]
 pub fn print_build() {
-    println!("clap_version:{}", build::clap_version());
+    println!("clap_long_version:{}", build::clap_long_version());
     println!("version:{}", build::version());
     println!("pkg_version:{}", build::PKG_VERSION);
     println!("pkg_version_major:{}", build::PKG_VERSION_MAJOR);

--- a/src/build_fn.rs
+++ b/src/build_fn.rs
@@ -29,6 +29,7 @@ build_env:{},{}"#,PKG_VERSION, TAG, SHORT_COMMIT, BUILD_TIME, RUST_VERSION, RUST
 }"##;
 
 const CLAP_VERSION_BRANCH_FN: &str = r##"#[allow(dead_code)]
+#[deprecated = "Replaced with `clap_long_version`"]
 pub fn clap_version() -> String {
     format!(r#"{}
 branch:{}
@@ -39,7 +40,28 @@ build_env:{},{}"#,PKG_VERSION, BRANCH, SHORT_COMMIT, BUILD_TIME, RUST_VERSION, R
 }"##;
 
 const CLAP_VERSION_TAG_FN: &str = r##"#[allow(dead_code)]
+#[deprecated = "Replaced with `clap_long_version`"]
 pub fn clap_version() -> String {
+    format!(r#"{}
+tag:{}
+commit_hash:{}
+build_time:{}
+build_env:{},{}"#,PKG_VERSION, TAG, SHORT_COMMIT, BUILD_TIME, RUST_VERSION, RUST_CHANNEL
+    )
+}"##;
+
+const CLAP_LONG_VERSION_BRANCH_FN: &str = r##"#[allow(dead_code)]
+pub fn clap_long_version() -> String {
+    format!(r#"{}
+branch:{}
+commit_hash:{}
+build_time:{}
+build_env:{},{}"#,PKG_VERSION, BRANCH, SHORT_COMMIT, BUILD_TIME, RUST_VERSION, RUST_CHANNEL
+    )
+}"##;
+
+const CLAP_LONG_VERSION_TAG_FN: &str = r##"#[allow(dead_code)]
+pub fn clap_long_version() -> String {
     format!(r#"{}
 tag:{}
 commit_hash:{}
@@ -52,6 +74,9 @@ const VERSION_FN_DESC: &str =
     r#"/// The common version function. It's so easy to use this function."#;
 
 const CLAP_VERSION_FN_DESC: &str =
+    r#"/// The common version function. It's so easy to use this function with clap_version()."#;
+
+const CLAP_LONG_VERSION_FN_DESC: &str =
     r#"/// The common version function. It's so easy to use this function with clap_version()."#;
 
 concat_fn!(version_branch_fn, VERSION_FN_DESC, VERSION_BRANCH_FN);
@@ -69,8 +94,19 @@ concat_fn!(
     CLAP_VERSION_TAG_FN
 );
 
+concat_fn!(
+    clap_long_version_branch_fn,
+    CLAP_LONG_VERSION_FN_DESC,
+    CLAP_LONG_VERSION_BRANCH_FN
+);
+concat_fn!(
+    clap_long_version_tag_fn,
+    CLAP_LONG_VERSION_FN_DESC,
+    CLAP_LONG_VERSION_TAG_FN
+);
+
 pub(crate) const BUILD_FN_VERSION: &str = "version";
-pub(crate) const BUILD_FN_CLAP_VERSION: &str = "clap_version";
+pub(crate) const BUILD_FN_CLAP_LONG_VERSION: &str = "clap_long_version";
 
 #[cfg(test)]
 mod tests {
@@ -82,5 +118,7 @@ mod tests {
         assert!(version_tag_fn().contains(VERSION_TAG_FN));
         assert!(clap_version_branch_fn().contains(CLAP_VERSION_BRANCH_FN));
         assert!(clap_version_tag_fn().contains(CLAP_VERSION_FN_DESC));
+        assert!(clap_long_version_branch_fn().contains(CLAP_LONG_VERSION_BRANCH_FN));
+        assert!(clap_long_version_tag_fn().contains(CLAP_LONG_VERSION_FN_DESC));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,9 @@ use std::io::Write;
 use std::path::Path;
 
 use crate::build_fn::{
-    clap_version_branch_fn, clap_version_tag_fn, version_branch_fn, version_tag_fn,
-    BUILD_FN_CLAP_VERSION, BUILD_FN_VERSION,
+    clap_long_version_branch_fn, clap_long_version_tag_fn, clap_version_branch_fn,
+    clap_version_tag_fn, version_branch_fn, version_tag_fn, BUILD_FN_CLAP_LONG_VERSION,
+    BUILD_FN_VERSION,
 };
 use chrono::Local;
 pub use err::{SdResult, ShadowError};
@@ -407,20 +408,33 @@ impl Shadow {
     }
 
     fn gen_version(&mut self) -> SdResult<Vec<&'static str>> {
-        let (ver_fn, clap_ver_fn) = match self.map.get(TAG) {
-            None => (version_branch_fn(), clap_version_branch_fn()),
+        let (ver_fn, clap_ver_fn, clap_long_ver_fn) = match self.map.get(TAG) {
+            None => (
+                version_branch_fn(),
+                clap_version_branch_fn(),
+                clap_long_version_branch_fn(),
+            ),
             Some(tag) => {
                 if !tag.v.is_empty() {
-                    (version_tag_fn(), clap_version_tag_fn())
+                    (
+                        version_tag_fn(),
+                        clap_version_tag_fn(),
+                        clap_long_version_tag_fn(),
+                    )
                 } else {
-                    (version_branch_fn(), clap_version_branch_fn())
+                    (
+                        version_branch_fn(),
+                        clap_version_branch_fn(),
+                        clap_long_version_branch_fn(),
+                    )
                 }
             }
         };
         writeln!(&self.f, "{}\n", ver_fn)?;
         writeln!(&self.f, "{}\n", clap_ver_fn)?;
+        writeln!(&self.f, "{}\n", clap_long_ver_fn)?;
 
-        Ok(vec![BUILD_FN_VERSION, BUILD_FN_CLAP_VERSION])
+        Ok(vec![BUILD_FN_VERSION, BUILD_FN_CLAP_LONG_VERSION])
     }
 
     fn gen_build_in(&self, build_fn: Vec<&'static str>) -> SdResult<()> {


### PR DESCRIPTION
To maintain compatibility, `clap_version` still exists, its just
deprecated.

Fixes #70