### PR TITLE
Use tzdb to support Windows hosts, too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ all-features = true
 [dependencies]
 is_debug = "1.0.1"
 const_format = "0.2.22"
-tz-rs = "0.6.11"
 time = { version = "0.3.11", features = ["formatting", "local-offset", "parsing"] }
+tzdb = { version = "0.2.7", default-features = false, features = ["local"] }
 
 #! Optional Dependencies:
 

--- a/src/data_time.rs
+++ b/src/data_time.rs
@@ -4,7 +4,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use time::format_description::well_known::{Rfc2822, Rfc3339};
 use time::UtcOffset;
 use time::{format_description, OffsetDateTime};
-use tz::TimeZone;
 
 pub enum DateTime {
     Local(OffsetDateTime),
@@ -50,7 +49,8 @@ impl DateTime {
     }
 
     pub fn local_now() -> Result<Self, Box<dyn Error>> {
-        let time_zone_local = TimeZone::local()?; // expensive call, should be cached
+        // expensive call, should be cached
+        let time_zone_local = tzdb::local_tz().ok_or("Could not get local timezone")?;
 
         let duration_since_epoch = SystemTime::now().duration_since(UNIX_EPOCH)?;
         let local_time_type =


### PR DESCRIPTION
tz-rs's `TimeZone::local()` is only supported for Linux hosts, but will
fail e.g. on Windows. Shadow-rs will fallback to use UTC dates, so it
will still be usable on Window.

tzdb's `local_tz()` bundles the Timezone Database, and works on Linux,
Windows, MacOS, FreeBSD, and NetBSD. While having local datetimes on
these host platforms is probably not particularly important, I still
think it's a better user experience.

tzdb itself uses tz-rs to make use of the timezone data.