### PR TITLE
Use tzdb with `std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ all-features = true
 is_debug = "1.0.1"
 const_format = "0.2.22"
 time = { version = "0.3.11", features = ["formatting", "local-offset", "parsing"] }
-tzdb = { version = "0.3.1", default-features = false, features = ["local"] }
+tzdb = { version = "0.3.4", default-features = false, features = ["local", "std"] }
 
 #! Optional Dependencies:
 


### PR DESCRIPTION
Shadow-rs uses `std::error::Error`s, which are only implemented by
tz-rs, and tzdb if their features `std` are enabled. Right now this is
not a problem, because even if you are using tzdb without default
features, tzdb still uses tz-rs with default-features. This is because
tz-rs did not yet have the feature gate when tzdb v0.3 was released.

Once tzdb v0.4 is released, the unconditional use of tzdb's std feature
will be fixed, which would break this project. So this PR is proactively
fixing the issue.