### PR TITLE
make `tzdb` an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,19 @@ all-features = true
 is_debug = "1.0.1"
 const_format = "0.2.22"
 time = { version = "0.3.11", features = ["formatting", "local-offset", "parsing"] }
-tzdb = { version = "0.4.3", default-features = false, features = ["local", "std"] }
 
 #! Optional Dependencies:
 
 ## Use `libgit2` as a backend for git operations
 git2 = { version = "0.15.0", default-features = false, optional = true }
 
+## Better support for querying the local system time
+tzdb = { version = "0.4.3", optional = true, default-features = false, features = ["local", "std"] }
+
 document-features = { version = "0.2", optional = true }
 
 [features]
-default = ["git2"]
+default = ["git2", "tzdb"]
 
 [workspace]
 members = ["example_shadow", "example_shadow_hook"]

--- a/src/data_time.rs
+++ b/src/data_time.rs
@@ -1,7 +1,9 @@
 use crate::Format;
 use std::error::Error;
+#[cfg(feature = "tzdb")]
 use std::time::{SystemTime, UNIX_EPOCH};
 use time::format_description::well_known::{Rfc2822, Rfc3339};
+#[cfg(feature = "tzdb")]
 use time::UtcOffset;
 use time::{format_description, OffsetDateTime};
 
@@ -48,6 +50,14 @@ impl DateTime {
         }
     }
 
+    #[cfg(not(feature = "tzdb"))]
+    pub fn local_now() -> Result<Self, Box<dyn Error>> {
+        OffsetDateTime::now_local()
+            .map(DateTime::Local)
+            .map_err(|e| e.into())
+    }
+
+    #[cfg(feature = "tzdb")]
     pub fn local_now() -> Result<Self, Box<dyn Error>> {
         // expensive call, should be cached
         let time_zone_local = tzdb::local_tz().ok_or("Could not get local timezone")?;


### PR DESCRIPTION
This improves the minimum supported rust version a bit, and can be used in cases where having access to the local timezone is less important.