### PR TITLE
shadow-rs: Fix linter on generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,13 +445,13 @@ impl Shadow {
 
         // append gen const
         for k in self.map.keys() {
-            let tmp = format!(r#"{}println!("{}:{{}}", {});{}"#, "\t", k, k, "\n");
+            let tmp = format!(r#"{}println!("{k}:{{{k}}}\n");{}"#, "\t", "\n");
             print_val.push_str(tmp.as_str());
         }
 
         // append gen fn
         for k in gen_const {
-            let tmp = format!(r#"{}println!("{}:{{}}\n", {});{}"#, "\t", k, k, "\n");
+            let tmp = format!(r#"{}println!("{k}:{{{k}}}\n");{}"#, "\t", "\n");
             print_val.push_str(tmp.as_str());
         }
 


### PR DESCRIPTION
The generated print_built_in() function triggers uninlined_format_args linter warning.
See https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

With that fix, it generates `"\tprintln!("FOO: {FOO}");\n"` code strings.

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>