### PR TITLE
Allow missing_docs for deprecated CLAP_VERSION constant

### DIFF
--- a/src/gen_const.rs
+++ b/src/gen_const.rs
@@ -32,7 +32,7 @@ build_time:{}
 build_env:{},{}"#,PKG_VERSION, TAG, SHORT_COMMIT, BUILD_TIME, RUST_VERSION, RUST_CHANNEL
 );"##;
 
-const CLAP_VERSION_BRANCH_CONST: &str = r##"#[allow(dead_code)]
+const CLAP_VERSION_BRANCH_CONST: &str = r##"#[allow(dead_code,missing_docs)]
 #[deprecated = "Replaced with `CLAP_LONG_VERSION`"]
 pub const CLAP_VERSION:&str = shadow_rs::formatcp!(r#"{}
 branch:{}
@@ -41,7 +41,7 @@ build_time:{}
 build_env:{},{}"#,PKG_VERSION, BRANCH, SHORT_COMMIT, BUILD_TIME, RUST_VERSION, RUST_CHANNEL
 );"##;
 
-const CLAP_VERSION_TAG_CONST: &str = r##"#[allow(dead_code)]
+const CLAP_VERSION_TAG_CONST: &str = r##"#[allow(dead_code,missing_docs)]
 #[deprecated = "Replaced with `CLAP_LONG_VERSION`"]
 pub const CLAP_VERSION:&str = shadow_rs::formatcp!(r#"{}
 tag:{}


### PR DESCRIPTION
Without this change, using `#![deny(missing_docs)]` fails:
```
error: missing documentation for a constant
   --> /Users/kartik/GH/project/target/debug/build/project-6de82e90c60d85bc/out/shadow.rs:588:1
    |
588 | pub const CLAP_VERSION:&str = shadow_rs::formatcp!(r#"{}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> src/lib.rs:13:9
    |
13  | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^
```

Another possible change is to remove the deprecated constant itself.