### PR TITLE
fix: ignore false-positive clippy lint trigger

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Build on nightly
         run: |
           cargo build --release
-          cargo +nightly clippy --all  --all-features -- -D warnings
+          cargo +nightly clippy --all  --all-features -- -D warnings -A clippy::literal_string_with_formatting_args
 
   test:
     strategy:


### PR DESCRIPTION
In newest nightly, there's a new clippy lint that triggers false-positively, without ignoring it, current master will be red on re-run