### PR TITLE
Add GIT_OPTIONAL_LOCKS to git invocation in command_git_status_file

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -613,6 +613,7 @@ fn command_git_status_file() -> String {
     let git_status_files =
         move |args: &[&str], grep: &[&str], awk: &[&str]| -> SdResult<Vec<String>> {
             let git_shell = Command::new("git")
+                .env("GIT_OPTIONAL_LOCKS", "0")
                 .args(args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
I've been having an issue with orphan `index.lock` files in my project, and did some digging to determine that they are being created by `shadow_rs`. I see that `GIT_OPTIONAL_LOCKS=0` is used in most `git` invocations, but is missing from this one in `command_git_status_file`. I believe the reason they are being orphaned in that my editor will kill the build when a file updates, and sometimes this happens while this operation is running.

This PR adds `GIT_OPTIONAL_LOCKS` to the `git` invocation in `command_git_status_file` to avoid creating an `index.lock` that might become an orphan.

Related: https://github.com/baoyachi/shadow-rs/issues/221
