### PR TITLE
Update time dependency to 0.3.47 for RUSTSEC-2026-0009

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 [dependencies]
 is_debug = { version = "1.1.0", default-features = false }
 const_format = { version = "0.2.22", default-features = false }
-time = { version = "0.3.36", features = ["formatting", "local-offset", "parsing"], default-features = false, optional = true }
+time = { version = "0.3.47", features = ["formatting", "local-offset", "parsing"], default-features = false, optional = true }
 
 
 #! Optional Dependencies:


### PR DESCRIPTION
Versions 0.3.6 through 0.3.46 of the `time` crate are vulnerable to denial of service via stack exhaustion when parsing RFC 2822 input. Version 0.3.47 fixes this by adding a recursion depth limit.

See: https://rustsec.org/advisories/RUSTSEC-2026-0009.html