### PR TITLE
Add `BuildPattern::AlwaysLazy` to enable lazy building for both debug and release.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -103,7 +103,7 @@ impl Display for ConstType {
 ///
 /// * `Lazy`: The lazy mode. In this mode, if the current Rust environment is set to `debug`,
 ///   the rebuild package will not run every time the build script is triggered.
-///   If the environment is set to `release`, it behaves the same as the `RealTime` mode.
+/// * `AlwaysLazy`: Same as `Lazy`, but applies to `release` rebuilds as well.
 /// * `RealTime`: The real-time mode. It will always trigger rebuilding a package upon any change,
 ///   regardless of whether the Rust environment is set to `debug` or `release`.
 /// * `Custom`: The custom build mode, an enhanced version of `RealTime` mode, allowing for user-defined conditions
@@ -113,6 +113,7 @@ impl Display for ConstType {
 pub enum BuildPattern {
     #[default]
     Lazy,
+    AlwaysLazy,
     RealTime,
     Custom {
         /// A list of paths that, if changed, will trigger a rebuild.
@@ -141,6 +142,9 @@ impl BuildPattern {
                 if is_debug() {
                     return;
                 }
+            }
+            BuildPattern::AlwaysLazy => {
+                return;
             }
             BuildPattern::RealTime => {}
             BuildPattern::Custom {


### PR DESCRIPTION
This allows developers to benefit from `shadow-rs` when incremental release builds are necessary for development: https://github.com/baoyachi/shadow-rs/issues/232

`AlwaysLazy` is a bit of a funky name. It would be more intuitive for `Lazy` to be something like `LazyInDebug`, so that `Lazy` is… simply "lazy". But that would be a breaking change to the build API at this point.

This introduces a bit of a footgun, because it allows the timestamp for a release build to be arbitrarily far out of date. A better middle ground might be to support rounding to a recent timestamp like midnight UTC (similar to what Chromium implemented: https://chromium.googlesource.com/chromium/src.git/+/08d91b75212b6592f05ff993d5a71c0f5a546563 ). But `AlwaysLazy` is a simple fix that unblocks `shadow-rs` for some use cases with  minimal code changes for now.